### PR TITLE
Forward non-attestation keys to real keystore in GENERATE mode (fixes -12)

### DIFF
--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/CertificateGen.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/CertificateGen.kt
@@ -184,28 +184,6 @@ object CertificateGen {
         return raw.onFailure { Log.e(TAG, "Failed to generate key pair", it) }.getOrNull()
     }
 
-    fun generateSecretKey(params: KeyGenParameters): javax.crypto.SecretKey? {
-        val raw = runCatching {
-            when (params.algorithm) {
-                Algorithm.AES ->
-                    javax.crypto.KeyGenerator.getInstance("AES")
-                        .apply { init(params.keySize.coerceAtLeast(128)) }
-                        .generateKey()
-
-                Algorithm.HMAC -> {
-                    val algo =
-                        "Hmac${CertificateUtils.digestName(params.digest.firstOrNull { it != 0 } ?: 0, false)}"
-                    javax.crypto.KeyGenerator.getInstance(algo)
-                        .apply { init(params.keySize.coerceAtLeast(256)) }
-                        .generateKey()
-                }
-
-                else -> null
-            }
-        }
-        return raw.onFailure { Log.e(TAG, "Failed to generate secret key", it) }.getOrNull()
-    }
-
     fun generateKeyPair(
         uid: Int,
         descriptor: KeyDescriptor,

--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/SecurityLevelInterceptor.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/SecurityLevelInterceptor.kt
@@ -237,6 +237,24 @@ class SecurityLevelInterceptor(private val original: IKeystoreSecurityLevel, pri
                             )
                             return Continue
                         }
+                        val needsForgedAttestation =
+                            challenge != null ||
+                                hasDeviceIdAttestation ||
+                                kgp.purpose.contains(KeyPurpose.ATTEST_KEY) ||
+                                attestationKeyDescriptor != null
+                        if (!needsForgedAttestation) {
+                            // Plain asymmetric keys without any attestation request are
+                            // only used for local crypto (e.g. RSA wrapping of stored
+                            // secrets). Forging them injects digest/attestation
+                            // authorizations the real operation cannot satisfy, which
+                            // surfaces as KM_ERROR_UNSUPPORTED_DIGEST (-12) on begin().
+                            // Forward to the real keystore instead.
+                            Log.i(
+                                TAG,
+                                "Forwarding plain asymmetric key to real keystore (no forge): uid=$callingUid alias=${keyDescriptor.alias}",
+                            )
+                            return Continue
+                        }
                         val pair =
                             CertificateGen.generateKeyPair(
                                 callingUid,

--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/SecurityLevelInterceptor.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/SecurityLevelInterceptor.kt
@@ -226,8 +226,16 @@ class SecurityLevelInterceptor(private val original: IKeystoreSecurityLevel, pri
                     forceForge -> {
                         val isSymmetric = kgp.algorithm == Algorithm.AES || kgp.algorithm == Algorithm.HMAC
                         if (isSymmetric) {
-                            val secretKey = CertificateGen.generateSecretKey(kgp) ?: return@runCatching
-                            return storeGeneratedKey(callingUid, keyDescriptor, kgp, null, secretKey, null, false)
+                            // Symmetric keys are never used for attestation, so forging them
+                            // gains nothing and breaks apps whose AES/HMAC operations don't
+                            // match the forged key's parameters (e.g. AES-GCM decrypt without
+                            // a digest tag -> KM_ERROR_UNSUPPORTED_DIGEST from authorizeOperation).
+                            // Forward to the real keystore instead.
+                            Log.i(
+                                TAG,
+                                "Forwarding symmetric key to real keystore (no forge): uid=$callingUid alias=${keyDescriptor.alias}",
+                            )
+                            return Continue
                         }
                         val pair =
                             CertificateGen.generateKeyPair(


### PR DESCRIPTION
## What

In `SecurityLevelInterceptor.generateKey`, the `forceForge` branch (GENERATE mode, `package!` in target.txt) currently software-forges **every** key the target app creates. This breaks two classes of keys that are never used for attestation:

1. **Symmetric AES/HMAC keys** — forging them makes the module own the key, and the forged key's parameters never match real operations (e.g. an AES-GCM decrypt carries no digest tag, so `authorizeOperation` rejects it with `KM_ERROR_UNSUPPORTED_DIGEST`, -12).
2. **Plain asymmetric keys** — keys generated with no challenge, no device-id attestation, no `ATTEST_KEY` purpose, and no attestation-key binding. These are only used for local crypto (e.g. RSA-wrapping stored secrets). Forged digest/attestation authorizations break real `begin()` calls with the same -12 error.

## Repro

ID Austria (`at.gv.oe.app`) on Android 16. Its VDA component (a.trust mobsig library) creates an RSA wrapping key and an AES key in AndroidKeyStore, then decrypts with AES/GCM:

```
android.security.KeyStoreException: Unsupported digest (internal Keystore code: -12 message: Operation not authorized)
```

An AES-GCM decrypt op carries no DIGEST tag (`op.digest = 0`), but the forged key's KeyGenParameters list one, so `keyParams.digest.isNotEmpty() && op.digest !in keyParams.digest` rejects the operation. The app surfaces this as `GNRL-VD-LI-A`.

## The fix

In the `forceForge` branch:

- Symmetric (AES/HMAC) keys → `return Continue` (real keystore).
- Asymmetric keys **with** any attestation request (challenge, device-id attestation, `ATTEST_KEY` purpose, attestation-key descriptor) → keep the existing keybox treatment.
- Plain asymmetric keys → `return Continue` (real keystore).

## Verification

Verified on-device (OnePlus 13, Android 16): with the patch, the app's AES and RSA keys live in the real keystore and binding + VDA activation proceed — the -12 rejection is gone. GENERATE mode is still required on devices whose real TEE cannot produce attestation certs (`teeBroken=true`); this change only stops intercepting keys that never need attestation.

## Impact

- `!` (GENERATE): symmetric and plain asymmetric keys now work for the app; attestation keys unchanged.
- `?` (LEAF_HACK) / AUTO: unchanged (those paths already forwarded these keys).
