### PR TITLE
Resolve conflict with TEEsim

### DIFF
--- a/module/customize.sh
+++ b/module/customize.sh
@@ -52,6 +52,11 @@ if [ -d /data/adb/modules/oh_my_keymint ]; then
     ui_print "! Oh My KeyMint module will be removed on next reboot"
 fi
 
+if [ -d /data/adb/modules/teesim ]; then
+    touch /data/adb/modules/teesim/remove
+    ui_print "! TEE Simulator module will be removed on next reboot"
+fi
+
 # --- Installation ---
 ui_print "- Extracting module files"
 for file in customize.sh module.prop post-fs-data.sh service.sh sepolicy.rule daemon; do


### PR DESCRIPTION
TEE Simulator's module ID has been changed. As a result, TS-OOS no longer replaces TEE Simulator's module ID with its own
